### PR TITLE
Add more authentication options

### DIFF
--- a/internal/clients/openstack.go
+++ b/internal/clients/openstack.go
@@ -65,11 +65,23 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 		// Set credentials in Terraform provider configuration.
 		ps.Configuration = map[string]any{
 			"auth_url":                      creds["auth_url"],
-			"tenant_name":                   creds["tenant_name"],
+			"region":                        creds["region"],
 			"user_name":                     creds["user_name"],
-			"password":                      creds["password"],
+			"user_id":                       creds["user_id"],
 			"application_credential_id":     creds["application_credential_id"],
+			"application_credential_name":   creds["application_credential_name"],
 			"application_credential_secret": creds["application_credential_secret"],
+			"tenant_id":                     creds["tenant_id"],
+			"tenant_name":                   creds["tenant_name"],
+			"password":                      creds["password"],
+			"token":                         creds["token"],
+			"user_domain_name":              creds["user_domain_name"],
+			"user_domain_id":                creds["user_domain_id"],
+			"project_domain_name":           creds["project_domain_name"],
+			"project_domain_id":             creds["project_domain_id"],
+			"domain_id":                     creds["domain_id"],
+			"domain_name":                   creds["domain_name"],
+			"default_domain":                creds["default_domain"],
 		}
 		return ps, nil
 	}


### PR DESCRIPTION
This PR will add additional authentication options to satisfy advanced needs. 

- region
- user_id
- application_credential_name
- tenant_id
- token
- user_domain_name
- user_domain_id
- project_domain_name
- project_domain_id
- domain_id
- domain_name
- default_domain

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with this two provider contents:

```json
{"user_name": "myusername",
"user_domain_name": "mydomain",
"tenant_name": "myproject",
"password": "mypassword",
"auth_url": "https://myauthurl.com/",
"region": "RegionOne",
"project_domain_name": "mydomain"}
```
and
```json
{"auth_url": "https://myauthurl.com/",
"application_credential_id": "myappcredid",
"application_credential_secret": "myappcredsec"}
```
