### PR TITLE
README: Align Provider manifest to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ kind: Provider
 metadata:
   name: provider-openstack
 spec:
-  package: crossplane-contrib/provider-openstack:vX.X.X
+  package: xpkg.upbound.io/crossplane-contrib/provider-openstack:vX.Y.Z
 EOF
 ```
 


### PR DESCRIPTION
### Description of your changes

The image suggested in the README lacks a host where to fetch it.

According to
https://marketplace.upbound.io/providers/crossplane-contrib/provider-openstack/v0.2.0, the package image is under `xpkg.upbound.io`.
Fixes #49

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Locally, following the README.

[contribution process]: https://git.io/fj2m9
