### PR TITLE
Add support for cacert_file

### DIFF
--- a/internal/clients/openstack.go
+++ b/internal/clients/openstack.go
@@ -82,6 +82,7 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 			"domain_id":                     creds["domain_id"],
 			"domain_name":                   creds["domain_name"],
 			"default_domain":                creds["default_domain"],
+			"cacert_file":			 creds["cacert_file"] 
 		}
 		return ps, nil
 	}

--- a/internal/clients/openstack.go
+++ b/internal/clients/openstack.go
@@ -82,7 +82,7 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 			"domain_id":                     creds["domain_id"],
 			"domain_name":                   creds["domain_name"],
 			"default_domain":                creds["default_domain"],
-			"cacert_file":			 creds["cacert_file"] 
+			"cacert_file":			 creds["cacert_file"],
 		}
 		return ps, nil
 	}

--- a/internal/clients/openstack.go
+++ b/internal/clients/openstack.go
@@ -82,7 +82,7 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 			"domain_id":                     creds["domain_id"],
 			"domain_name":                   creds["domain_name"],
 			"default_domain":                creds["default_domain"],
-			"cacert_file":			 creds["cacert_file"],
+			"cacert_file":                   creds["cacert_file"],
 		}
 		return ps, nil
 	}


### PR DESCRIPTION
### Description of your changes

This MR will support the addition of cacert_file.
Fixes #80 : You will now be able to enter a cacert_file location.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make submodules; make reviewable test` to ensure this PR is ready for review.
