### PR TITLE
Add cross-reference for security groups

### DIFF
--- a/apis/compute/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/compute/v1alpha1/zz_generated.deepcopy.go
@@ -1597,17 +1597,6 @@ func (in *InstanceV2InitParameters) DeepCopyInto(out *InstanceV2InitParameters) 
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
-	if in.SecurityGroups != nil {
-		in, out := &in.SecurityGroups, &out.SecurityGroups
-		*out = make([]*string, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(string)
-				**out = **in
-			}
-		}
-	}
 	if in.StopBeforeDestroy != nil {
 		in, out := &in.StopBeforeDestroy, &out.StopBeforeDestroy
 		*out = new(bool)
@@ -2066,6 +2055,18 @@ func (in *InstanceV2Parameters) DeepCopyInto(out *InstanceV2Parameters) {
 				**out = **in
 			}
 		}
+	}
+	if in.SecurityGroupsRefs != nil {
+		in, out := &in.SecurityGroupsRefs, &out.SecurityGroupsRefs
+		*out = make([]v1.Reference, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
+	if in.SecurityGroupsSelector != nil {
+		in, out := &in.SecurityGroupsSelector, &out.SecurityGroupsSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.StopBeforeDestroy != nil {
 		in, out := &in.StopBeforeDestroy, &out.StopBeforeDestroy

--- a/apis/compute/v1alpha1/zz_instancev2_types.go
+++ b/apis/compute/v1alpha1/zz_instancev2_types.go
@@ -295,14 +295,6 @@ type InstanceV2InitParameters struct {
 	// the instance should be launched. The available hints are described below.
 	SchedulerHints []SchedulerHintsInitParameters `json:"schedulerHints,omitempty" tf:"scheduler_hints,omitempty"`
 
-	// An array of one or more security group names
-	// to associate with the server. Changing this results in adding/removing
-	// security groups from the existing server. Note: When attaching the
-	// instance to networks using Ports, place the security groups on the Port
-	// and not the instance. Note: Names should be used and not ids, as ids
-	// trigger unnecessary updates.
-	SecurityGroups []*string `json:"securityGroups,omitempty" tf:"security_groups,omitempty"`
-
 	// Whether to try stop instance gracefully
 	// before destroying it, thus giving chance for guest OS daemons to stop correctly.
 	// If instance doesn't stop within timeout, it will be destroyed anyway.
@@ -606,8 +598,17 @@ type InstanceV2Parameters struct {
 	// instance to networks using Ports, place the security groups on the Port
 	// and not the instance. Note: Names should be used and not ids, as ids
 	// trigger unnecessary updates.
+	// +crossplane:generate:reference:type=SecgroupV2
 	// +kubebuilder:validation:Optional
 	SecurityGroups []*string `json:"securityGroups,omitempty" tf:"security_groups,omitempty"`
+
+	// References to SecgroupV2 to populate securityGroups.
+	// +kubebuilder:validation:Optional
+	SecurityGroupsRefs []v1.Reference `json:"securityGroupsRefs,omitempty" tf:"-"`
+
+	// Selector for a list of SecgroupV2 to populate securityGroups.
+	// +kubebuilder:validation:Optional
+	SecurityGroupsSelector *v1.Selector `json:"securityGroupsSelector,omitempty" tf:"-"`
 
 	// Whether to try stop instance gracefully
 	// before destroying it, thus giving chance for guest OS daemons to stop correctly.

--- a/config/compute/config.go
+++ b/config/compute/config.go
@@ -14,6 +14,9 @@ func Configure(p *config.Provider) {
 		r.References["key_pair"] = config.Reference{
 			Type: "KeypairV2",
 		}
+		r.References["security_groups"] = config.Reference{
+			Type: "SecgroupV2",
+		}
 	})
 	p.AddResourceConfigurator("openstack_compute_quotaset_v2", func(r *config.Resource) {
 		r.References["project_id"] = config.Reference{

--- a/examples-generated/compute/floatingipassociatev2.yaml
+++ b/examples-generated/compute/floatingipassociatev2.yaml
@@ -29,8 +29,8 @@ spec:
       matchLabels:
         testing.upbound.io/example-name: example
     name: instance_1
-    securityGroups:
-    - default
+    securityGroupsRefs:
+    - name: example
 
 ---
 

--- a/examples-generated/compute/instancev2.yaml
+++ b/examples-generated/compute/instancev2.yaml
@@ -18,5 +18,5 @@ spec:
     name: basic
     network:
     - name: my_network
-    securityGroups:
-    - default
+    securityGroupsRefs:
+    - name: example

--- a/examples-generated/compute/interfaceattachv2.yaml
+++ b/examples-generated/compute/interfaceattachv2.yaml
@@ -24,8 +24,8 @@ metadata:
 spec:
   forProvider:
     name: instance_1
-    securityGroups:
-    - default
+    securityGroupsRefs:
+    - name: example
 
 ---
 

--- a/examples-generated/compute/volumeattachv2.yaml
+++ b/examples-generated/compute/volumeattachv2.yaml
@@ -39,5 +39,5 @@ metadata:
 spec:
   forProvider:
     name: instance_1
-    securityGroups:
-    - default
+    securityGroupsRefs:
+    - name: example

--- a/examples-generated/networking/networkv2.yaml
+++ b/examples-generated/networking/networkv2.yaml
@@ -26,8 +26,8 @@ spec:
     name: instance_1
     network:
     - port: ${openstack_networking_port_v2.port_1.id}
-    securityGroups:
-    - ${openstack_compute_secgroup_v2.secgroup_1.name}
+    securityGroupsRefs:
+    - name: secgroup_1
 
 ---
 

--- a/examples-generated/networking/trunkv2.yaml
+++ b/examples-generated/networking/trunkv2.yaml
@@ -31,8 +31,8 @@ spec:
     name: instance_1
     network:
     - port: ${openstack_networking_port_v2.parent_port_1.id}
-    securityGroups:
-    - default
+    securityGroupsRefs:
+    - name: example
 
 ---
 

--- a/package/crds/compute.openstack.crossplane.io_instancev2s.yaml
+++ b/package/crds/compute.openstack.crossplane.io_instancev2s.yaml
@@ -411,6 +411,82 @@ spec:
                     items:
                       type: string
                     type: array
+                  securityGroupsRefs:
+                    description: References to SecgroupV2 to populate securityGroups.
+                    items:
+                      description: A Reference to a named object.
+                      properties:
+                        name:
+                          description: Name of the referenced object.
+                          type: string
+                        policy:
+                          description: Policies for referencing.
+                          properties:
+                            resolution:
+                              default: Required
+                              description: Resolution specifies whether resolution
+                                of this reference is required. The default is 'Required',
+                                which means the reconcile will fail if the reference
+                                cannot be resolved. 'Optional' means this reference
+                                will be a no-op if it cannot be resolved.
+                              enum:
+                              - Required
+                              - Optional
+                              type: string
+                            resolve:
+                              description: Resolve specifies when this reference should
+                                be resolved. The default is 'IfNotPresent', which
+                                will attempt to resolve the reference only when the
+                                corresponding field is not present. Use 'Always' to
+                                resolve the reference on every reconcile.
+                              enum:
+                              - Always
+                              - IfNotPresent
+                              type: string
+                          type: object
+                      required:
+                      - name
+                      type: object
+                    type: array
+                  securityGroupsSelector:
+                    description: Selector for a list of SecgroupV2 to populate securityGroups.
+                    properties:
+                      matchControllerRef:
+                        description: MatchControllerRef ensures an object with the
+                          same controller reference as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: Resolution specifies whether resolution of
+                              this reference is required. The default is 'Required',
+                              which means the reconcile will fail if the reference
+                              cannot be resolved. 'Optional' means this reference
+                              will be a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: Resolve specifies when this reference should
+                              be resolved. The default is 'IfNotPresent', which will
+                              attempt to resolve the reference only when the corresponding
+                              field is not present. Use 'Always' to resolve the reference
+                              on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   stopBeforeDestroy:
                     description: Whether to try stop instance gracefully before destroying
                       it, thus giving chance for guest OS daemons to stop correctly.
@@ -707,16 +783,6 @@ spec:
                           description: The name of a cell to host the instance.
                           type: string
                       type: object
-                    type: array
-                  securityGroups:
-                    description: 'An array of one or more security group names to
-                      associate with the server. Changing this results in adding/removing
-                      security groups from the existing server. Note: When attaching
-                      the instance to networks using Ports, place the security groups
-                      on the Port and not the instance. Note: Names should be used
-                      and not ids, as ids trigger unnecessary updates.'
-                    items:
-                      type: string
                     type: array
                   stopBeforeDestroy:
                     description: Whether to try stop instance gracefully before destroying


### PR DESCRIPTION

This PR adds support for cross-referencing security groups #105 following the [cross-referencing](https://github.com/crossplane/upjet/blob/main/docs/configuring-a-resource.md#cross-resource-referencing) guide.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make submodules; make reviewable test` to ensure this PR is ready for review.
