### PR TITLE
Fix reference from subnet to network (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix wrong reference from Neutron Subnets to Networks (#137)
+
 ## [0.7.0] - 2025-05-22
 
 ### Changed

--- a/apis/networking/v1alpha1/zz_generated.resolvers.go
+++ b/apis/networking/v1alpha1/zz_generated.resolvers.go
@@ -558,8 +558,8 @@ func (mg *SubnetV2) ResolveReferences(ctx context.Context, c client.Reader) erro
 		Reference:    mg.Spec.ForProvider.NetworkIDRef,
 		Selector:     mg.Spec.ForProvider.NetworkIDSelector,
 		To: reference.To{
-			List:    &SubnetV2List{},
-			Managed: &SubnetV2{},
+			List:    &NetworkV2List{},
+			Managed: &NetworkV2{},
 		},
 	})
 	if err != nil {
@@ -574,8 +574,8 @@ func (mg *SubnetV2) ResolveReferences(ctx context.Context, c client.Reader) erro
 		Reference:    mg.Spec.InitProvider.NetworkIDRef,
 		Selector:     mg.Spec.InitProvider.NetworkIDSelector,
 		To: reference.To{
-			List:    &SubnetV2List{},
-			Managed: &SubnetV2{},
+			List:    &NetworkV2List{},
+			Managed: &NetworkV2{},
 		},
 	})
 	if err != nil {

--- a/apis/networking/v1alpha1/zz_subnetv2_types.go
+++ b/apis/networking/v1alpha1/zz_subnetv2_types.go
@@ -100,14 +100,14 @@ type SubnetV2InitParameters struct {
 
 	// The UUID of the parent network. Changing this
 	// creates a new subnet.
-	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/networking/v1alpha1.SubnetV2
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/networking/v1alpha1.NetworkV2
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 
-	// Reference to a SubnetV2 in networking to populate networkId.
+	// Reference to a NetworkV2 in networking to populate networkId.
 	// +kubebuilder:validation:Optional
 	NetworkIDRef *v1.Reference `json:"networkIdRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetV2 in networking to populate networkId.
+	// Selector for a NetworkV2 in networking to populate networkId.
 	// +kubebuilder:validation:Optional
 	NetworkIDSelector *v1.Selector `json:"networkIdSelector,omitempty" tf:"-"`
 
@@ -317,15 +317,15 @@ type SubnetV2Parameters struct {
 
 	// The UUID of the parent network. Changing this
 	// creates a new subnet.
-	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/networking/v1alpha1.SubnetV2
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/networking/v1alpha1.NetworkV2
 	// +kubebuilder:validation:Optional
 	NetworkID *string `json:"networkId,omitempty" tf:"network_id,omitempty"`
 
-	// Reference to a SubnetV2 in networking to populate networkId.
+	// Reference to a NetworkV2 in networking to populate networkId.
 	// +kubebuilder:validation:Optional
 	NetworkIDRef *v1.Reference `json:"networkIdRef,omitempty" tf:"-"`
 
-	// Selector for a SubnetV2 in networking to populate networkId.
+	// Selector for a NetworkV2 in networking to populate networkId.
 	// +kubebuilder:validation:Optional
 	NetworkIDSelector *v1.Selector `json:"networkIdSelector,omitempty" tf:"-"`
 

--- a/config/networking/config.go
+++ b/config/networking/config.go
@@ -6,7 +6,7 @@ import "github.com/crossplane/upjet/pkg/config"
 func Configure(p *config.Provider) {
 	p.AddResourceConfigurator("openstack_networking_subnet_v2", func(r *config.Resource) {
 		r.References["network_id"] = config.Reference{
-			TerraformName: "openstack_networking_subnet_v2",
+			TerraformName: "openstack_networking_network_v2",
 		}
 		r.LateInitializer = config.LateInitializer{
 			IgnoredFields: []string{"allocation_pools"},

--- a/package/crds/networking.openstack.crossplane.io_subnetv2s.yaml
+++ b/package/crds/networking.openstack.crossplane.io_subnetv2s.yaml
@@ -154,7 +154,7 @@ spec:
                       creates a new subnet.
                     type: string
                   networkIdRef:
-                    description: Reference to a SubnetV2 in networking to populate
+                    description: Reference to a NetworkV2 in networking to populate
                       networkId.
                     properties:
                       name:
@@ -189,7 +189,7 @@ spec:
                     - name
                     type: object
                   networkIdSelector:
-                    description: Selector for a SubnetV2 in networking to populate
+                    description: Selector for a NetworkV2 in networking to populate
                       networkId.
                     properties:
                       matchControllerRef:
@@ -370,7 +370,7 @@ spec:
                       creates a new subnet.
                     type: string
                   networkIdRef:
-                    description: Reference to a SubnetV2 in networking to populate
+                    description: Reference to a NetworkV2 in networking to populate
                       networkId.
                     properties:
                       name:
@@ -405,7 +405,7 @@ spec:
                     - name
                     type: object
                   networkIdSelector:
-                    description: Selector for a SubnetV2 in networking to populate
+                    description: Selector for a NetworkV2 in networking to populate
                       networkId.
                     properties:
                       matchControllerRef:


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Fixes the reference from a Neutron Subnet to a Neutron Network.

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #137

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make submodules; make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
