### PR TITLE
Fix/issue 101 instance flavor resize loop

### DIFF
--- a/apis/cluster/compute/v1alpha1/zz_instancev2_terraformed.go
+++ b/apis/cluster/compute/v1alpha1/zz_instancev2_terraformed.go
@@ -120,6 +120,8 @@ func (tr *InstanceV2) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("FlavorID"))
+	opts = append(opts, resource.WithNameFilter("FlavorName"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/apis/namespaced/compute/v1alpha1/zz_instancev2_terraformed.go
+++ b/apis/namespaced/compute/v1alpha1/zz_instancev2_terraformed.go
@@ -120,6 +120,8 @@ func (tr *InstanceV2) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("FlavorID"))
+	opts = append(opts, resource.WithNameFilter("FlavorName"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/cluster/compute/config.go
+++ b/config/cluster/compute/config.go
@@ -11,6 +11,12 @@ func Configure(p *config.Provider) {
 		// r.ExternalName = config.ExternalName{}
 		// r.ShortGroup = "openstack"
 		// r.Version = "v1alpha22"
+		// Terraform state always has flavor_name populated. If flavor_id is managed,
+		// late initialization of flavor_name can introduce conflicting desired state
+		// and cause resize loops during reconciliation.
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"flavor_name"},
+		}
 		r.References["key_pair"] = config.Reference{
 			TerraformName: "openstack_compute_keypair_v2",
 		}

--- a/config/cluster/compute/config.go
+++ b/config/cluster/compute/config.go
@@ -11,11 +11,11 @@ func Configure(p *config.Provider) {
 		// r.ExternalName = config.ExternalName{}
 		// r.ShortGroup = "openstack"
 		// r.Version = "v1alpha22"
-		// Terraform state always has flavor_name populated. If flavor_id is managed,
-		// late initialization of flavor_name can introduce conflicting desired state
-		// and cause resize loops during reconciliation.
+		// Terraform state always has both flavor_id and flavor_name populated.
+		// Late initialization of the counterpart field can introduce conflicting
+		// desired state and cause resize loops during reconciliation.
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"flavor_name"},
+			IgnoredFields: []string{"flavor_id", "flavor_name"},
 		}
 		r.References["key_pair"] = config.Reference{
 			TerraformName: "openstack_compute_keypair_v2",

--- a/config/namespaced/compute/config.go
+++ b/config/namespaced/compute/config.go
@@ -11,6 +11,12 @@ func Configure(p *config.Provider) {
 		// r.ExternalName = config.ExternalName{}
 		// r.ShortGroup = "openstack"
 		// r.Version = "v1alpha22"
+		// Terraform state always has flavor_name populated. If flavor_id is managed,
+		// late initialization of flavor_name can introduce conflicting desired state
+		// and cause resize loops during reconciliation.
+		r.LateInitializer = config.LateInitializer{
+			IgnoredFields: []string{"flavor_name"},
+		}
 		r.References["key_pair"] = config.Reference{
 			TerraformName: "openstack_compute_keypair_v2",
 		}

--- a/config/namespaced/compute/config.go
+++ b/config/namespaced/compute/config.go
@@ -11,11 +11,11 @@ func Configure(p *config.Provider) {
 		// r.ExternalName = config.ExternalName{}
 		// r.ShortGroup = "openstack"
 		// r.Version = "v1alpha22"
-		// Terraform state always has flavor_name populated. If flavor_id is managed,
-		// late initialization of flavor_name can introduce conflicting desired state
-		// and cause resize loops during reconciliation.
+		// Terraform state always has both flavor_id and flavor_name populated.
+		// Late initialization of the counterpart field can introduce conflicting
+		// desired state and cause resize loops during reconciliation.
 		r.LateInitializer = config.LateInitializer{
-			IgnoredFields: []string{"flavor_name"},
+			IgnoredFields: []string{"flavor_id", "flavor_name"},
 		}
 		r.References["key_pair"] = config.Reference{
 			TerraformName: "openstack_compute_keypair_v2",


### PR DESCRIPTION
## Description of your changes

Fixes crossplane-contrib/provider-openstack#101

I have:

- [x] Read and followed Crossplane's contribution process.
- [x] Run `make submodules; make reviewable test` to ensure this PR is ready for review.

This change prevents `InstanceV2` resize loops when changing flavor by excluding both `flavor_id` and `flavor_name` from late-initialization.  
Also includes regenerated files from `make reviewable`.

## How has this code been tested

- `make submodules`
- `PATH="$(go env GOPATH)/bin:$PATH" make reviewable test`
