### PR TITLE
feat: Add portIdRef and portIdSelector support to RouterInterfaceV2

### DIFF
--- a/apis/cluster/networking/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/networking/v1alpha1/zz_generated.deepcopy.go
@@ -4612,6 +4612,16 @@ func (in *RouterInterfaceV2InitParameters) DeepCopyInto(out *RouterInterfaceV2In
 		*out = new(string)
 		**out = **in
 	}
+	if in.PortIDRef != nil {
+		in, out := &in.PortIDRef, &out.PortIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PortIDSelector != nil {
+		in, out := &in.PortIDSelector, &out.PortIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Region != nil {
 		in, out := &in.Region, &out.Region
 		*out = new(string)
@@ -4748,6 +4758,16 @@ func (in *RouterInterfaceV2Parameters) DeepCopyInto(out *RouterInterfaceV2Parame
 		in, out := &in.PortID, &out.PortID
 		*out = new(string)
 		**out = **in
+	}
+	if in.PortIDRef != nil {
+		in, out := &in.PortIDRef, &out.PortIDRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PortIDSelector != nil {
+		in, out := &in.PortIDSelector, &out.PortIDSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Region != nil {
 		in, out := &in.Region, &out.Region

--- a/apis/cluster/networking/v1alpha1/zz_generated.resolvers.go
+++ b/apis/cluster/networking/v1alpha1/zz_generated.resolvers.go
@@ -370,6 +370,23 @@ func (mg *RouterInterfaceV2) ResolveReferences(ctx context.Context, c client.Rea
 	var err error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PortID),
+		Extract:      reference.ExternalName(),
+		Namespace:    mg.GetNamespace(),
+		Reference:    mg.Spec.ForProvider.PortIDRef,
+		Selector:     mg.Spec.ForProvider.PortIDSelector,
+		To: reference.To{
+			List:    &PortV2List{},
+			Managed: &PortV2{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.PortID")
+	}
+	mg.Spec.ForProvider.PortID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.PortIDRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.RouterID),
 		Extract:      reference.ExternalName(),
 		Namespace:    mg.GetNamespace(),
@@ -402,6 +419,23 @@ func (mg *RouterInterfaceV2) ResolveReferences(ctx context.Context, c client.Rea
 	}
 	mg.Spec.ForProvider.SubnetID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.SubnetIDRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PortID),
+		Extract:      reference.ExternalName(),
+		Namespace:    mg.GetNamespace(),
+		Reference:    mg.Spec.InitProvider.PortIDRef,
+		Selector:     mg.Spec.InitProvider.PortIDSelector,
+		To: reference.To{
+			List:    &PortV2List{},
+			Managed: &PortV2{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.PortID")
+	}
+	mg.Spec.InitProvider.PortID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.PortIDRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.RouterID),

--- a/apis/cluster/networking/v1alpha1/zz_routerinterfacev2_types.go
+++ b/apis/cluster/networking/v1alpha1/zz_routerinterfacev2_types.go
@@ -24,7 +24,16 @@ type RouterInterfaceV2InitParameters struct {
 
 	// ID of the port this interface connects to. Changing
 	// this creates a new router interface.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/cluster/networking/v1alpha1.PortV2
 	PortID *string `json:"portId,omitempty" tf:"port_id,omitempty"`
+
+	// Reference to a PortV2 in networking to populate portId.
+	// +kubebuilder:validation:Optional
+	PortIDRef *v1.Reference `json:"portIdRef,omitempty" tf:"-"`
+
+	// Selector for a PortV2 in networking to populate portId.
+	// +kubebuilder:validation:Optional
+	PortIDSelector *v1.Selector `json:"portIdSelector,omitempty" tf:"-"`
 
 	// The region in which to obtain the V2 networking client.
 	// A networking client is needed to create a router. If omitted, the
@@ -97,8 +106,17 @@ type RouterInterfaceV2Parameters struct {
 
 	// ID of the port this interface connects to. Changing
 	// this creates a new router interface.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/cluster/networking/v1alpha1.PortV2
 	// +kubebuilder:validation:Optional
 	PortID *string `json:"portId,omitempty" tf:"port_id,omitempty"`
+
+	// Reference to a PortV2 in networking to populate portId.
+	// +kubebuilder:validation:Optional
+	PortIDRef *v1.Reference `json:"portIdRef,omitempty" tf:"-"`
+
+	// Selector for a PortV2 in networking to populate portId.
+	// +kubebuilder:validation:Optional
+	PortIDSelector *v1.Selector `json:"portIdSelector,omitempty" tf:"-"`
 
 	// The region in which to obtain the V2 networking client.
 	// A networking client is needed to create a router. If omitted, the

--- a/apis/namespaced/networking/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/networking/v1alpha1/zz_generated.deepcopy.go
@@ -4612,6 +4612,16 @@ func (in *RouterInterfaceV2InitParameters) DeepCopyInto(out *RouterInterfaceV2In
 		*out = new(string)
 		**out = **in
 	}
+	if in.PortIDRef != nil {
+		in, out := &in.PortIDRef, &out.PortIDRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PortIDSelector != nil {
+		in, out := &in.PortIDSelector, &out.PortIDSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Region != nil {
 		in, out := &in.Region, &out.Region
 		*out = new(string)
@@ -4748,6 +4758,16 @@ func (in *RouterInterfaceV2Parameters) DeepCopyInto(out *RouterInterfaceV2Parame
 		in, out := &in.PortID, &out.PortID
 		*out = new(string)
 		**out = **in
+	}
+	if in.PortIDRef != nil {
+		in, out := &in.PortIDRef, &out.PortIDRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.PortIDSelector != nil {
+		in, out := &in.PortIDSelector, &out.PortIDSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Region != nil {
 		in, out := &in.Region, &out.Region

--- a/apis/namespaced/networking/v1alpha1/zz_generated.resolvers.go
+++ b/apis/namespaced/networking/v1alpha1/zz_generated.resolvers.go
@@ -370,6 +370,23 @@ func (mg *RouterInterfaceV2) ResolveReferences(ctx context.Context, c client.Rea
 	var err error
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PortID),
+		Extract:      reference.ExternalName(),
+		Namespace:    mg.GetNamespace(),
+		Reference:    mg.Spec.ForProvider.PortIDRef,
+		Selector:     mg.Spec.ForProvider.PortIDSelector,
+		To: reference.To{
+			List:    &PortV2List{},
+			Managed: &PortV2{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.PortID")
+	}
+	mg.Spec.ForProvider.PortID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.PortIDRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.RouterID),
 		Extract:      reference.ExternalName(),
 		Namespace:    mg.GetNamespace(),
@@ -402,6 +419,23 @@ func (mg *RouterInterfaceV2) ResolveReferences(ctx context.Context, c client.Rea
 	}
 	mg.Spec.ForProvider.SubnetID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.SubnetIDRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PortID),
+		Extract:      reference.ExternalName(),
+		Namespace:    mg.GetNamespace(),
+		Reference:    mg.Spec.InitProvider.PortIDRef,
+		Selector:     mg.Spec.InitProvider.PortIDSelector,
+		To: reference.To{
+			List:    &PortV2List{},
+			Managed: &PortV2{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.PortID")
+	}
+	mg.Spec.InitProvider.PortID = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.PortIDRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.RouterID),

--- a/apis/namespaced/networking/v1alpha1/zz_routerinterfacev2_types.go
+++ b/apis/namespaced/networking/v1alpha1/zz_routerinterfacev2_types.go
@@ -25,7 +25,16 @@ type RouterInterfaceV2InitParameters struct {
 
 	// ID of the port this interface connects to. Changing
 	// this creates a new router interface.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/namespaced/networking/v1alpha1.PortV2
 	PortID *string `json:"portId,omitempty" tf:"port_id,omitempty"`
+
+	// Reference to a PortV2 in networking to populate portId.
+	// +kubebuilder:validation:Optional
+	PortIDRef *v1.NamespacedReference `json:"portIdRef,omitempty" tf:"-"`
+
+	// Selector for a PortV2 in networking to populate portId.
+	// +kubebuilder:validation:Optional
+	PortIDSelector *v1.NamespacedSelector `json:"portIdSelector,omitempty" tf:"-"`
 
 	// The region in which to obtain the V2 networking client.
 	// A networking client is needed to create a router. If omitted, the
@@ -98,8 +107,17 @@ type RouterInterfaceV2Parameters struct {
 
 	// ID of the port this interface connects to. Changing
 	// this creates a new router interface.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/namespaced/networking/v1alpha1.PortV2
 	// +kubebuilder:validation:Optional
 	PortID *string `json:"portId,omitempty" tf:"port_id,omitempty"`
+
+	// Reference to a PortV2 in networking to populate portId.
+	// +kubebuilder:validation:Optional
+	PortIDRef *v1.NamespacedReference `json:"portIdRef,omitempty" tf:"-"`
+
+	// Selector for a PortV2 in networking to populate portId.
+	// +kubebuilder:validation:Optional
+	PortIDSelector *v1.NamespacedSelector `json:"portIdSelector,omitempty" tf:"-"`
 
 	// The region in which to obtain the V2 networking client.
 	// A networking client is needed to create a router. If omitted, the

--- a/config/cluster/networking/config.go
+++ b/config/cluster/networking/config.go
@@ -19,6 +19,9 @@ func Configure(p *config.Provider) {
 		r.References["subnet_id"] = config.Reference{
 			TerraformName: "openstack_networking_subnet_v2",
 		}
+		r.References["port_id"] = config.Reference{
+			TerraformName: "openstack_networking_port_v2",
+		}
 	})
 	p.AddResourceConfigurator("openstack_networking_router_v2", func(r *config.Resource) {
 		r.LateInitializer = config.LateInitializer{

--- a/config/namespaced/networking/config.go
+++ b/config/namespaced/networking/config.go
@@ -19,6 +19,9 @@ func Configure(p *config.Provider) {
 		r.References["subnet_id"] = config.Reference{
 			TerraformName: "openstack_networking_subnet_v2",
 		}
+		r.References["port_id"] = config.Reference{
+			TerraformName: "openstack_networking_port_v2",
+		}
 	})
 	p.AddResourceConfigurator("openstack_networking_router_v2", func(r *config.Resource) {
 		r.LateInitializer = config.LateInitializer{

--- a/package/crds/networking.openstack.crossplane.io_routerinterfacev2s.yaml
+++ b/package/crds/networking.openstack.crossplane.io_routerinterfacev2s.yaml
@@ -84,6 +84,80 @@ spec:
                       ID of the port this interface connects to. Changing
                       this creates a new router interface.
                     type: string
+                  portIdRef:
+                    description: Reference to a PortV2 in networking to populate portId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  portIdSelector:
+                    description: Selector for a PortV2 in networking to populate portId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   region:
                     description: |-
                       The region in which to obtain the V2 networking client.
@@ -278,6 +352,80 @@ spec:
                       ID of the port this interface connects to. Changing
                       this creates a new router interface.
                     type: string
+                  portIdRef:
+                    description: Reference to a PortV2 in networking to populate portId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  portIdSelector:
+                    description: Selector for a PortV2 in networking to populate portId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   region:
                     description: |-
                       The region in which to obtain the V2 networking client.

--- a/package/crds/networking.openstack.m.crossplane.io_routerinterfacev2s.yaml
+++ b/package/crds/networking.openstack.m.crossplane.io_routerinterfacev2s.yaml
@@ -70,6 +70,86 @@ spec:
                       ID of the port this interface connects to. Changing
                       this creates a new router interface.
                     type: string
+                  portIdRef:
+                    description: Reference to a PortV2 in networking to populate portId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      namespace:
+                        description: Namespace of the referenced object
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  portIdSelector:
+                    description: Selector for a PortV2 in networking to populate portId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      namespace:
+                        description: Namespace for the selector
+                        type: string
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   region:
                     description: |-
                       The region in which to obtain the V2 networking client.
@@ -276,6 +356,86 @@ spec:
                       ID of the port this interface connects to. Changing
                       this creates a new router interface.
                     type: string
+                  portIdRef:
+                    description: Reference to a PortV2 in networking to populate portId.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      namespace:
+                        description: Namespace of the referenced object
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  portIdSelector:
+                    description: Selector for a PortV2 in networking to populate portId.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      namespace:
+                        description: Namespace for the selector
+                        type: string
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   region:
                     description: |-
                       The region in which to obtain the V2 networking client.


### PR DESCRIPTION
### Description of your changes

Add cross-reference for portIdRef and portIdSelector to RouterInterfaceV2

Fixes #171

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make submodules; make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

In progress
