### PR TITLE
feat: Add floatingIpRef and floatingIpSelector support to FloatingipAssociateV2

### DIFF
--- a/apis/cluster/networking/v1alpha1/floatingipv2_extractor.go
+++ b/apis/cluster/networking/v1alpha1/floatingipv2_extractor.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 Upbound Inc.
+Copyright 2023 Jakob Schlagenhaufer
+Copyright 2025 Yannick Schlosser
+*/
+
+package v1alpha1
+
+import (
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reference"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+)
+
+// ExtractFloatingIPAddress returns the allocated floating IP address from
+// status.atProvider.address of a FloatingipV2 managed resource.
+func ExtractFloatingIPAddress() reference.ExtractValueFn {
+	return func(mg resource.Managed) string {
+		f, ok := any(mg).(*FloatingipV2)
+		if !ok {
+			return ""
+		}
+		if f.Status.AtProvider.Address == nil {
+			return ""
+		}
+		return *f.Status.AtProvider.Address
+	}
+}

--- a/apis/cluster/networking/v1alpha1/zz_floatingipassociatev2_types.go
+++ b/apis/cluster/networking/v1alpha1/zz_floatingipassociatev2_types.go
@@ -20,7 +20,17 @@ type FloatingipAssociateV2InitParameters struct {
 	FixedIP *string `json:"fixedIp,omitempty" tf:"fixed_ip,omitempty"`
 
 	// IP Address of an existing floating IP.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/cluster/networking/v1alpha1.FloatingipV2
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-openstack/apis/cluster/networking/v1alpha1.ExtractFloatingIPAddress()
 	FloatingIP *string `json:"floatingIp,omitempty" tf:"floating_ip,omitempty"`
+
+	// Reference to a FloatingipV2 in networking to populate floatingIp.
+	// +kubebuilder:validation:Optional
+	FloatingIPRef *v1.Reference `json:"floatingIpRef,omitempty" tf:"-"`
+
+	// Selector for a FloatingipV2 in networking to populate floatingIp.
+	// +kubebuilder:validation:Optional
+	FloatingIPSelector *v1.Selector `json:"floatingIpSelector,omitempty" tf:"-"`
 
 	// ID of an existing port with at least one IP address to
 	// associate with this floating IP.
@@ -70,8 +80,18 @@ type FloatingipAssociateV2Parameters struct {
 	FixedIP *string `json:"fixedIp,omitempty" tf:"fixed_ip,omitempty"`
 
 	// IP Address of an existing floating IP.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/cluster/networking/v1alpha1.FloatingipV2
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-openstack/apis/cluster/networking/v1alpha1.ExtractFloatingIPAddress()
 	// +kubebuilder:validation:Optional
 	FloatingIP *string `json:"floatingIp,omitempty" tf:"floating_ip,omitempty"`
+
+	// Reference to a FloatingipV2 in networking to populate floatingIp.
+	// +kubebuilder:validation:Optional
+	FloatingIPRef *v1.Reference `json:"floatingIpRef,omitempty" tf:"-"`
+
+	// Selector for a FloatingipV2 in networking to populate floatingIp.
+	// +kubebuilder:validation:Optional
+	FloatingIPSelector *v1.Selector `json:"floatingIpSelector,omitempty" tf:"-"`
 
 	// ID of an existing port with at least one IP address to
 	// associate with this floating IP.
@@ -133,9 +153,8 @@ type FloatingipAssociateV2Status struct {
 type FloatingipAssociateV2 struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.floatingIp) || (has(self.initProvider) && has(self.initProvider.floatingIp))",message="spec.forProvider.floatingIp is a required parameter"
-	Spec   FloatingipAssociateV2Spec   `json:"spec"`
-	Status FloatingipAssociateV2Status `json:"status,omitempty"`
+	Spec              FloatingipAssociateV2Spec   `json:"spec"`
+	Status            FloatingipAssociateV2Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/cluster/networking/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/cluster/networking/v1alpha1/zz_generated.deepcopy.go
@@ -796,6 +796,16 @@ func (in *FloatingipAssociateV2InitParameters) DeepCopyInto(out *FloatingipAssoc
 		*out = new(string)
 		**out = **in
 	}
+	if in.FloatingIPRef != nil {
+		in, out := &in.FloatingIPRef, &out.FloatingIPRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.FloatingIPSelector != nil {
+		in, out := &in.FloatingIPSelector, &out.FloatingIPSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PortID != nil {
 		in, out := &in.PortID, &out.PortID
 		*out = new(string)
@@ -912,6 +922,16 @@ func (in *FloatingipAssociateV2Parameters) DeepCopyInto(out *FloatingipAssociate
 		in, out := &in.FloatingIP, &out.FloatingIP
 		*out = new(string)
 		**out = **in
+	}
+	if in.FloatingIPRef != nil {
+		in, out := &in.FloatingIPRef, &out.FloatingIPRef
+		*out = new(v1.Reference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.FloatingIPSelector != nil {
+		in, out := &in.FloatingIPSelector, &out.FloatingIPSelector
+		*out = new(v1.Selector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PortID != nil {
 		in, out := &in.PortID, &out.PortID

--- a/apis/cluster/networking/v1alpha1/zz_generated.resolvers.go
+++ b/apis/cluster/networking/v1alpha1/zz_generated.resolvers.go
@@ -25,6 +25,23 @@ func (mg *FloatingipAssociateV2) ResolveReferences(ctx context.Context, c client
 	var err error
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.FloatingIP),
+		Extract:      ExtractFloatingIPAddress(),
+		Namespace:    mg.GetNamespace(),
+		Reference:    mg.Spec.ForProvider.FloatingIPRef,
+		Selector:     mg.Spec.ForProvider.FloatingIPSelector,
+		To: reference.To{
+			List:    &FloatingipV2List{},
+			Managed: &FloatingipV2{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.FloatingIP")
+	}
+	mg.Spec.ForProvider.FloatingIP = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.FloatingIPRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PortID),
 		Extract:      resource.ExtractResourceID(),
 		Namespace:    mg.GetNamespace(),
@@ -40,6 +57,23 @@ func (mg *FloatingipAssociateV2) ResolveReferences(ctx context.Context, c client
 	}
 	mg.Spec.ForProvider.PortID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.PortIDRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.FloatingIP),
+		Extract:      ExtractFloatingIPAddress(),
+		Namespace:    mg.GetNamespace(),
+		Reference:    mg.Spec.InitProvider.FloatingIPRef,
+		Selector:     mg.Spec.InitProvider.FloatingIPSelector,
+		To: reference.To{
+			List:    &FloatingipV2List{},
+			Managed: &FloatingipV2{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.FloatingIP")
+	}
+	mg.Spec.InitProvider.FloatingIP = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.FloatingIPRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.ResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PortID),

--- a/apis/namespaced/networking/v1alpha1/floatingipv2_extractor.go
+++ b/apis/namespaced/networking/v1alpha1/floatingipv2_extractor.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2022 Upbound Inc.
+Copyright 2023 Jakob Schlagenhaufer
+Copyright 2025 Yannick Schlosser
+*/
+
+package v1alpha1
+
+import (
+	"github.com/crossplane/crossplane-runtime/v2/pkg/reference"
+	"github.com/crossplane/crossplane-runtime/v2/pkg/resource"
+)
+
+// ExtractFloatingIPAddress returns the allocated floating IP address from
+// status.atProvider.address of a FloatingipV2 managed resource.
+func ExtractFloatingIPAddress() reference.ExtractValueFn {
+	return func(mg resource.Managed) string {
+		f, ok := any(mg).(*FloatingipV2)
+		if !ok {
+			return ""
+		}
+		if f.Status.AtProvider.Address == nil {
+			return ""
+		}
+		return *f.Status.AtProvider.Address
+	}
+}

--- a/apis/namespaced/networking/v1alpha1/zz_floatingipassociatev2_types.go
+++ b/apis/namespaced/networking/v1alpha1/zz_floatingipassociatev2_types.go
@@ -21,7 +21,17 @@ type FloatingipAssociateV2InitParameters struct {
 	FixedIP *string `json:"fixedIp,omitempty" tf:"fixed_ip,omitempty"`
 
 	// IP Address of an existing floating IP.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/namespaced/networking/v1alpha1.FloatingipV2
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-openstack/apis/namespaced/networking/v1alpha1.ExtractFloatingIPAddress()
 	FloatingIP *string `json:"floatingIp,omitempty" tf:"floating_ip,omitempty"`
+
+	// Reference to a FloatingipV2 in networking to populate floatingIp.
+	// +kubebuilder:validation:Optional
+	FloatingIPRef *v1.NamespacedReference `json:"floatingIpRef,omitempty" tf:"-"`
+
+	// Selector for a FloatingipV2 in networking to populate floatingIp.
+	// +kubebuilder:validation:Optional
+	FloatingIPSelector *v1.NamespacedSelector `json:"floatingIpSelector,omitempty" tf:"-"`
 
 	// ID of an existing port with at least one IP address to
 	// associate with this floating IP.
@@ -71,8 +81,18 @@ type FloatingipAssociateV2Parameters struct {
 	FixedIP *string `json:"fixedIp,omitempty" tf:"fixed_ip,omitempty"`
 
 	// IP Address of an existing floating IP.
+	// +crossplane:generate:reference:type=github.com/crossplane-contrib/provider-openstack/apis/namespaced/networking/v1alpha1.FloatingipV2
+	// +crossplane:generate:reference:extractor=github.com/crossplane-contrib/provider-openstack/apis/namespaced/networking/v1alpha1.ExtractFloatingIPAddress()
 	// +kubebuilder:validation:Optional
 	FloatingIP *string `json:"floatingIp,omitempty" tf:"floating_ip,omitempty"`
+
+	// Reference to a FloatingipV2 in networking to populate floatingIp.
+	// +kubebuilder:validation:Optional
+	FloatingIPRef *v1.NamespacedReference `json:"floatingIpRef,omitempty" tf:"-"`
+
+	// Selector for a FloatingipV2 in networking to populate floatingIp.
+	// +kubebuilder:validation:Optional
+	FloatingIPSelector *v1.NamespacedSelector `json:"floatingIpSelector,omitempty" tf:"-"`
 
 	// ID of an existing port with at least one IP address to
 	// associate with this floating IP.
@@ -134,9 +154,8 @@ type FloatingipAssociateV2Status struct {
 type FloatingipAssociateV2 struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	// +kubebuilder:validation:XValidation:rule="!('*' in self.managementPolicies || 'Create' in self.managementPolicies || 'Update' in self.managementPolicies) || has(self.forProvider.floatingIp) || (has(self.initProvider) && has(self.initProvider.floatingIp))",message="spec.forProvider.floatingIp is a required parameter"
-	Spec   FloatingipAssociateV2Spec   `json:"spec"`
-	Status FloatingipAssociateV2Status `json:"status,omitempty"`
+	Spec              FloatingipAssociateV2Spec   `json:"spec"`
+	Status            FloatingipAssociateV2Status `json:"status,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/apis/namespaced/networking/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/namespaced/networking/v1alpha1/zz_generated.deepcopy.go
@@ -796,6 +796,16 @@ func (in *FloatingipAssociateV2InitParameters) DeepCopyInto(out *FloatingipAssoc
 		*out = new(string)
 		**out = **in
 	}
+	if in.FloatingIPRef != nil {
+		in, out := &in.FloatingIPRef, &out.FloatingIPRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.FloatingIPSelector != nil {
+		in, out := &in.FloatingIPSelector, &out.FloatingIPSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PortID != nil {
 		in, out := &in.PortID, &out.PortID
 		*out = new(string)
@@ -912,6 +922,16 @@ func (in *FloatingipAssociateV2Parameters) DeepCopyInto(out *FloatingipAssociate
 		in, out := &in.FloatingIP, &out.FloatingIP
 		*out = new(string)
 		**out = **in
+	}
+	if in.FloatingIPRef != nil {
+		in, out := &in.FloatingIPRef, &out.FloatingIPRef
+		*out = new(v1.NamespacedReference)
+		(*in).DeepCopyInto(*out)
+	}
+	if in.FloatingIPSelector != nil {
+		in, out := &in.FloatingIPSelector, &out.FloatingIPSelector
+		*out = new(v1.NamespacedSelector)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.PortID != nil {
 		in, out := &in.PortID, &out.PortID

--- a/apis/namespaced/networking/v1alpha1/zz_generated.resolvers.go
+++ b/apis/namespaced/networking/v1alpha1/zz_generated.resolvers.go
@@ -25,6 +25,23 @@ func (mg *FloatingipAssociateV2) ResolveReferences(ctx context.Context, c client
 	var err error
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.FloatingIP),
+		Extract:      ExtractFloatingIPAddress(),
+		Namespace:    mg.GetNamespace(),
+		Reference:    mg.Spec.ForProvider.FloatingIPRef,
+		Selector:     mg.Spec.ForProvider.FloatingIPSelector,
+		To: reference.To{
+			List:    &FloatingipV2List{},
+			Managed: &FloatingipV2{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.ForProvider.FloatingIP")
+	}
+	mg.Spec.ForProvider.FloatingIP = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.ForProvider.FloatingIPRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.ForProvider.PortID),
 		Extract:      resource.ExtractResourceID(),
 		Namespace:    mg.GetNamespace(),
@@ -40,6 +57,23 @@ func (mg *FloatingipAssociateV2) ResolveReferences(ctx context.Context, c client
 	}
 	mg.Spec.ForProvider.PortID = reference.ToPtrValue(rsp.ResolvedValue)
 	mg.Spec.ForProvider.PortIDRef = rsp.ResolvedReference
+
+	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
+		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.FloatingIP),
+		Extract:      ExtractFloatingIPAddress(),
+		Namespace:    mg.GetNamespace(),
+		Reference:    mg.Spec.InitProvider.FloatingIPRef,
+		Selector:     mg.Spec.InitProvider.FloatingIPSelector,
+		To: reference.To{
+			List:    &FloatingipV2List{},
+			Managed: &FloatingipV2{},
+		},
+	})
+	if err != nil {
+		return errors.Wrap(err, "mg.Spec.InitProvider.FloatingIP")
+	}
+	mg.Spec.InitProvider.FloatingIP = reference.ToPtrValue(rsp.ResolvedValue)
+	mg.Spec.InitProvider.FloatingIPRef = rsp.ResolvedReference
 
 	rsp, err = r.Resolve(ctx, reference.NamespacedResolutionRequest{
 		CurrentValue: reference.FromPtrValue(mg.Spec.InitProvider.PortID),

--- a/config/cluster/networking/config.go
+++ b/config/cluster/networking/config.go
@@ -12,6 +12,12 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{"allocation_pools"},
 		}
 	})
+	p.AddResourceConfigurator("openstack_networking_floatingip_associate_v2", func(r *config.Resource) {
+		r.References["floating_ip"] = config.Reference{
+			TerraformName: "openstack_networking_floatingip_v2",
+			Extractor:     "github.com/crossplane-contrib/provider-openstack/apis/cluster/networking/v1alpha1.ExtractFloatingIPAddress()",
+		}
+	})
 	p.AddResourceConfigurator("openstack_networking_router_interface_v2", func(r *config.Resource) {
 		r.References["router_id"] = config.Reference{
 			TerraformName: "openstack_networking_router_v2",

--- a/config/namespaced/networking/config.go
+++ b/config/namespaced/networking/config.go
@@ -12,6 +12,12 @@ func Configure(p *config.Provider) {
 			IgnoredFields: []string{"allocation_pools"},
 		}
 	})
+	p.AddResourceConfigurator("openstack_networking_floatingip_associate_v2", func(r *config.Resource) {
+		r.References["floating_ip"] = config.Reference{
+			TerraformName: "openstack_networking_floatingip_v2",
+			Extractor:     "github.com/crossplane-contrib/provider-openstack/apis/namespaced/networking/v1alpha1.ExtractFloatingIPAddress()",
+		}
+	})
 	p.AddResourceConfigurator("openstack_networking_router_interface_v2", func(r *config.Resource) {
 		r.References["router_id"] = config.Reference{
 			TerraformName: "openstack_networking_router_v2",

--- a/examples-generated/cluster/networking/v1alpha1/floatingipassociatev2.yaml
+++ b/examples-generated/cluster/networking/v1alpha1/floatingipassociatev2.yaml
@@ -8,7 +8,9 @@ metadata:
   name: fip-1
 spec:
   forProvider:
-    floatingIp: 1.2.3.4
+    floatingIpSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
     portIdSelector:
       matchLabels:
         testing.upbound.io/example-name: port_1

--- a/examples-generated/namespaced/networking/v1alpha1/floatingipassociatev2.yaml
+++ b/examples-generated/namespaced/networking/v1alpha1/floatingipassociatev2.yaml
@@ -9,7 +9,9 @@ metadata:
   namespace: upbound-system
 spec:
   forProvider:
-    floatingIp: 1.2.3.4
+    floatingIpSelector:
+      matchLabels:
+        testing.upbound.io/example-name: example
     portIdSelector:
       matchLabels:
         testing.upbound.io/example-name: port_1

--- a/package/crds/networking.openstack.crossplane.io_floatingipassociatev2s.yaml
+++ b/package/crds/networking.openstack.crossplane.io_floatingipassociatev2s.yaml
@@ -78,6 +78,82 @@ spec:
                   floatingIp:
                     description: IP Address of an existing floating IP.
                     type: string
+                  floatingIpRef:
+                    description: Reference to a FloatingipV2 in networking to populate
+                      floatingIp.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  floatingIpSelector:
+                    description: Selector for a FloatingipV2 in networking to populate
+                      floatingIp.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   portId:
                     description: |-
                       ID of an existing port with at least one IP address to
@@ -184,6 +260,82 @@ spec:
                   floatingIp:
                     description: IP Address of an existing floating IP.
                     type: string
+                  floatingIpRef:
+                    description: Reference to a FloatingipV2 in networking to populate
+                      floatingIp.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  floatingIpSelector:
+                    description: Selector for a FloatingipV2 in networking to populate
+                      floatingIp.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   portId:
                     description: |-
                       ID of an existing port with at least one IP address to
@@ -358,11 +510,6 @@ spec:
             required:
             - forProvider
             type: object
-            x-kubernetes-validations:
-            - message: spec.forProvider.floatingIp is a required parameter
-              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
-                || ''Update'' in self.managementPolicies) || has(self.forProvider.floatingIp)
-                || (has(self.initProvider) && has(self.initProvider.floatingIp))'
           status:
             description: FloatingipAssociateV2Status defines the observed state of
               FloatingipAssociateV2.

--- a/package/crds/networking.openstack.m.crossplane.io_floatingipassociatev2s.yaml
+++ b/package/crds/networking.openstack.m.crossplane.io_floatingipassociatev2s.yaml
@@ -64,6 +64,88 @@ spec:
                   floatingIp:
                     description: IP Address of an existing floating IP.
                     type: string
+                  floatingIpRef:
+                    description: Reference to a FloatingipV2 in networking to populate
+                      floatingIp.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      namespace:
+                        description: Namespace of the referenced object
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  floatingIpSelector:
+                    description: Selector for a FloatingipV2 in networking to populate
+                      floatingIp.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      namespace:
+                        description: Namespace for the selector
+                        type: string
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   portId:
                     description: |-
                       ID of an existing port with at least one IP address to
@@ -176,6 +258,88 @@ spec:
                   floatingIp:
                     description: IP Address of an existing floating IP.
                     type: string
+                  floatingIpRef:
+                    description: Reference to a FloatingipV2 in networking to populate
+                      floatingIp.
+                    properties:
+                      name:
+                        description: Name of the referenced object.
+                        type: string
+                      namespace:
+                        description: Namespace of the referenced object
+                        type: string
+                      policy:
+                        description: Policies for referencing.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    required:
+                    - name
+                    type: object
+                  floatingIpSelector:
+                    description: Selector for a FloatingipV2 in networking to populate
+                      floatingIp.
+                    properties:
+                      matchControllerRef:
+                        description: |-
+                          MatchControllerRef ensures an object with the same controller reference
+                          as the selecting object is selected.
+                        type: boolean
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        description: MatchLabels ensures an object with matching labels
+                          is selected.
+                        type: object
+                      namespace:
+                        description: Namespace for the selector
+                        type: string
+                      policy:
+                        description: Policies for selection.
+                        properties:
+                          resolution:
+                            default: Required
+                            description: |-
+                              Resolution specifies whether resolution of this reference is required.
+                              The default is 'Required', which means the reconcile will fail if the
+                              reference cannot be resolved. 'Optional' means this reference will be
+                              a no-op if it cannot be resolved.
+                            enum:
+                            - Required
+                            - Optional
+                            type: string
+                          resolve:
+                            description: |-
+                              Resolve specifies when this reference should be resolved. The default
+                              is 'IfNotPresent', which will attempt to resolve the reference only when
+                              the corresponding field is not present. Use 'Always' to resolve the
+                              reference on every reconcile.
+                            enum:
+                            - Always
+                            - IfNotPresent
+                            type: string
+                        type: object
+                    type: object
                   portId:
                     description: |-
                       ID of an existing port with at least one IP address to
@@ -328,11 +492,6 @@ spec:
             required:
             - forProvider
             type: object
-            x-kubernetes-validations:
-            - message: spec.forProvider.floatingIp is a required parameter
-              rule: '!(''*'' in self.managementPolicies || ''Create'' in self.managementPolicies
-                || ''Update'' in self.managementPolicies) || has(self.forProvider.floatingIp)
-                || (has(self.initProvider) && has(self.initProvider.floatingIp))'
           status:
             description: FloatingipAssociateV2Status defines the observed state of
               FloatingipAssociateV2.


### PR DESCRIPTION
### Description of your changes

Add cross-reference floatingIpRef and floatingIpSelector to FloatingipAssociateV2 

Fixe #174 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make submodules; make reviewable test` to ensure this PR is ready for review.

Tested and works.